### PR TITLE
Generate lenses

### DIFF
--- a/Sources/Meta/Generators/Environments/LensGenerator.swift
+++ b/Sources/Meta/Generators/Environments/LensGenerator.swift
@@ -1,16 +1,16 @@
-public class IsoGenerator {
+public class LensGenerator {
     public init() {}
 }
 
-extension IsoGenerator: HasFileSystem {
+extension LensGenerator: HasFileSystem {
     public var fileSystem: FileSystem {
         MacFileSystem()
     }
 }
 
-extension IsoGenerator: HasCodeGenerator {
+extension LensGenerator: HasCodeGenerator {
     public var generator: CodeGenerator {
-        SwiftSyntaxGenerator(visitor: IsoVisitor(),
+        SwiftSyntaxGenerator(visitor: LensVisitor(),
                              requiredImports: Set(["import BowOptics"]))
     }
 }

--- a/Sources/Meta/Visitors/LensVisitor.swift
+++ b/Sources/Meta/Visitors/LensVisitor.swift
@@ -1,0 +1,34 @@
+import SwiftSyntax
+
+public class LensVisitor: SyntaxVisitor, CodegenVisitor {
+    private(set) public var generatedCode: String = ""
+    
+    public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+        let structName = node.identifier.description.trimmingCharacters(in: .whitespacesAndNewlines)
+        let fields = node.fields
+        let lensesCode = generateLenses(for: fields, structName: structName)
+        
+        let code = """
+        extension \(structName) {
+        \(lensesCode)
+        }
+        
+        """
+        print(code, to: &generatedCode)
+        
+        return .skipChildren
+    }
+    
+    private func generateLenses(for fields: [Field], structName: String) -> String {
+        fields.map { field in self.generateLens(field, structName: structName) }.joined(separator: "\n\n")
+    }
+    
+    private func generateLens(_ field: Field, structName: String) -> String {
+        """
+            static var \(field.name)Lens: Lens<\(structName), \(field.type)> {
+                Lens(get: { $0.\(field.name) },
+                     set: { $0.copy(with\(field.name.capitalized): $1) })
+            }
+        """
+    }
+}

--- a/Sources/OpticsGenerator/main.swift
+++ b/Sources/OpticsGenerator/main.swift
@@ -40,6 +40,10 @@ func generateIso(_ input: URL, _ output: URL) -> Task<Void> {
     generate(input, output, "IsoGeneration.swift", IsoGenerator())
 }
 
+func generateLens(_ input: URL, _ output: URL) -> Task<Void> {
+    generate(input, output, "LensGeneration.swift", LensGenerator())
+}
+
 func main() -> Task<Void> {
     let input = Task<URL>.var()
     let output = Task<URL>.var()
@@ -48,6 +52,7 @@ func main() -> Task<Void> {
         (input, output) <- getArguments(),
                         |<-generateCopy(input.get, output.get),
                         |<-generateIso(input.get, output.get),
+                        |<-generateLens(input.get, output.get),
         yield:())^
 }
 

--- a/Tests/MetaTests/Extensions/Snapshotting+Codegen.swift
+++ b/Tests/MetaTests/Extensions/Snapshotting+Codegen.swift
@@ -17,6 +17,8 @@ extension Snapshotting where Value == URL, Format == String {
     
     static let iso: Snapshotting<URL, String> = .generatedCode(visitor: IsoVisitor())
     
+    static let lens: Snapshotting<URL, String> = .generatedCode(visitor: LensVisitor())
+    
     static func generatedCode<D: CodegenDependencies>(using environment: D) -> Snapshotting<URL, String> {
         var strategy = Snapshotting<String, String>.lines.pullback { (url: URL) -> String in
             try! generateCode(forFilesIn: url.path)

--- a/Tests/MetaTests/Generators/LensGeneratorTests.swift
+++ b/Tests/MetaTests/Generators/LensGeneratorTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+import SnapshotTesting
+import Meta
+
+class LensGeneratorTests: XCTestCase {
+    func testLensGeneratorMultipleFiles() {
+        assertSnapshot(matching: URL.meta.fixtures, as: .generatedCode(using: LensGenerator()))
+    }
+}

--- a/Tests/MetaTests/Generators/__Snapshots__/LensGeneratorTests/testLensGeneratorMultipleFiles.1.swift
+++ b/Tests/MetaTests/Generators/__Snapshots__/LensGeneratorTests/testLensGeneratorMultipleFiles.1.swift
@@ -1,0 +1,78 @@
+import Bow
+import BowOptics
+import Foundation
+
+
+// MARK: - Generated from file Company.swift
+
+extension Company {
+    static var ceoLens: Lens<Company, Employee> {
+        Lens(get: { $0.ceo },
+             set: { $0.copy(withCeo: $1) })
+    }
+
+    static var ctoLens: Lens<Company, Option<Employee>> {
+        Lens(get: { $0.cto },
+             set: { $0.copy(withCto: $1) })
+    }
+
+    static var employeesLens: Lens<Company, ArrayK<Employee>> {
+        Lens(get: { $0.employees },
+             set: { $0.copy(withEmployees: $1) })
+    }
+}
+
+extension Employee {
+    static var nameLens: Lens<Employee, String> {
+        Lens(get: { $0.name },
+             set: { $0.copy(withName: $1) })
+    }
+}
+
+
+// MARK: - Generated from file Author.swift
+
+extension Author {
+    static var nameLens: Lens<Author, String> {
+        Lens(get: { $0.name },
+             set: { $0.copy(withName: $1) })
+    }
+
+    static var socialLens: Lens<Author, [SocialNetwork]> {
+        Lens(get: { $0.social },
+             set: { $0.copy(withSocial: $1) })
+    }
+}
+
+
+// MARK: - Generated from file Article.swift
+
+extension Article {
+    static var titleLens: Lens<Article, String> {
+        Lens(get: { $0.title },
+             set: { $0.copy(withTitle: $1) })
+    }
+
+    static var subtitleLens: Lens<Article, String?> {
+        Lens(get: { $0.subtitle },
+             set: { $0.copy(withSubtitle: $1) })
+    }
+
+    static var stateLens: Lens<Article, PublicationState> {
+        Lens(get: { $0.state },
+             set: { $0.copy(withState: $1) })
+    }
+
+    static var authorLens: Lens<Article, Author> {
+        Lens(get: { $0.author },
+             set: { $0.copy(withAuthor: $1) })
+    }
+}
+
+extension Blog {
+    static var articlesLens: Lens<Blog, [Article]> {
+        Lens(get: { $0.articles },
+             set: { $0.copy(withArticles: $1) })
+    }
+}
+

--- a/Tests/MetaTests/Visitors/LensVisitorTests.swift
+++ b/Tests/MetaTests/Visitors/LensVisitorTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+import Meta
+import SnapshotTesting
+
+class LensVisitorTests: XCTestCase {
+    func testGeneratedLens() {
+        assertSnapshot(matching: URL.meta.fixtures.file(.article), as: .lens)
+    }
+}

--- a/Tests/MetaTests/Visitors/__Snapshots__/LensVisitorTests/testGeneratedLens.1.txt
+++ b/Tests/MetaTests/Visitors/__Snapshots__/LensVisitorTests/testGeneratedLens.1.txt
@@ -1,0 +1,29 @@
+extension Article {
+    static var titleLens: Lens<Article, String> {
+        Lens(get: { $0.title },
+             set: { $0.copy(withTitle: $1) })
+    }
+
+    static var subtitleLens: Lens<Article, String?> {
+        Lens(get: { $0.subtitle },
+             set: { $0.copy(withSubtitle: $1) })
+    }
+
+    static var stateLens: Lens<Article, PublicationState> {
+        Lens(get: { $0.state },
+             set: { $0.copy(withState: $1) })
+    }
+
+    static var authorLens: Lens<Article, Author> {
+        Lens(get: { $0.author },
+             set: { $0.copy(withAuthor: $1) })
+    }
+}
+
+extension Blog {
+    static var articlesLens: Lens<Blog, [Article]> {
+        Lens(get: { $0.articles },
+             set: { $0.copy(withArticles: $1) })
+    }
+}
+

--- a/bow-meta.xcodeproj/project.pbxproj
+++ b/bow-meta.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		11039BF7234E845B0022EE33 /* LensVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11039BF6234E845B0022EE33 /* LensVisitor.swift */; };
 		11039BFA234E865F0022EE33 /* LensVisitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11039BF8234E86590022EE33 /* LensVisitorTests.swift */; };
+		11039BFC234E87DC0022EE33 /* LensGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11039BFB234E87DC0022EE33 /* LensGenerator.swift */; };
+		11039BFE234E881C0022EE33 /* LensGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11039BFD234E881C0022EE33 /* LensGeneratorTests.swift */; };
+		11039C01234E885D0022EE33 /* testLensGeneratorMultipleFiles.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11039C00234E885D0022EE33 /* testLensGeneratorMultipleFiles.1.swift */; };
 		11175E8023462ED000F26788 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 11175E7F23462ED000F26788 /* SnapshotTesting */; };
 		11175E862346310800F26788 /* Snapshotting+Codegen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11175E84234630FD00F26788 /* Snapshotting+Codegen.swift */; };
 		111F8501234DCABB003FE646 /* CopyVisitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111F84FF234DCA98003FE646 /* CopyVisitorTests.swift */; };
@@ -78,6 +81,9 @@
 /* Begin PBXFileReference section */
 		11039BF6234E845B0022EE33 /* LensVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LensVisitor.swift; sourceTree = "<group>"; };
 		11039BF8234E86590022EE33 /* LensVisitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LensVisitorTests.swift; sourceTree = "<group>"; };
+		11039BFB234E87DC0022EE33 /* LensGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LensGenerator.swift; sourceTree = "<group>"; };
+		11039BFD234E881C0022EE33 /* LensGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LensGeneratorTests.swift; sourceTree = "<group>"; };
+		11039C00234E885D0022EE33 /* testLensGeneratorMultipleFiles.1.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = testLensGeneratorMultipleFiles.1.swift; sourceTree = "<group>"; };
 		11175E84234630FD00F26788 /* Snapshotting+Codegen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Snapshotting+Codegen.swift"; sourceTree = "<group>"; };
 		111F84FF234DCA98003FE646 /* CopyVisitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyVisitorTests.swift; sourceTree = "<group>"; };
 		111F8502234DCDBB003FE646 /* IsoVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IsoVisitor.swift; sourceTree = "<group>"; };
@@ -161,6 +167,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		11039BFF234E885D0022EE33 /* LensGeneratorTests */ = {
+			isa = PBXGroup;
+			children = (
+				11039C00234E885D0022EE33 /* testLensGeneratorMultipleFiles.1.swift */,
+			);
+			path = LensGeneratorTests;
+			sourceTree = "<group>";
+		};
 		111F850E234DD338003FE646 /* IsoGeneratorTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -263,6 +277,7 @@
 				11433402234B3EAF00BFF775 /* __Snapshots__ */,
 				114333FD234B3DC700BFF775 /* CopyGeneratorTests.swift */,
 				111F850B234DD2BE003FE646 /* IsoGeneratorTests.swift */,
+				11039BFD234E881C0022EE33 /* LensGeneratorTests.swift */,
 			);
 			path = Generators;
 			sourceTree = "<group>";
@@ -279,6 +294,7 @@
 		11433402234B3EAF00BFF775 /* __Snapshots__ */ = {
 			isa = PBXGroup;
 			children = (
+				11039BFF234E885D0022EE33 /* LensGeneratorTests */,
 				111F850E234DD338003FE646 /* IsoGeneratorTests */,
 				11433403234B3EAF00BFF775 /* CopyGeneratorTests */,
 			);
@@ -326,6 +342,7 @@
 			children = (
 				11433422234B50E200BFF775 /* CopyGenerator.swift */,
 				111F8509234DD28D003FE646 /* IsoGenerator.swift */,
+				11039BFB234E87DC0022EE33 /* LensGenerator.swift */,
 			);
 			path = Environments;
 			sourceTree = "<group>";
@@ -585,6 +602,7 @@
 				11433412234B439200BFF775 /* FileSystem.swift in Sources */,
 				11433423234B50E200BFF775 /* CopyGenerator.swift in Sources */,
 				113746E82343A51A00D9C1AD /* ComputedPropertyVisitor.swift in Sources */,
+				11039BFC234E87DC0022EE33 /* LensGenerator.swift in Sources */,
 				11433417234B468D00BFF775 /* CodeGenerator.swift in Sources */,
 				11039BF7234E845B0022EE33 /* LensVisitor.swift in Sources */,
 				11433415234B45FF00BFF775 /* MacFileSystem.swift in Sources */,
@@ -617,10 +635,12 @@
 				111F850D234DD2D6003FE646 /* IsoGeneratorTests.swift in Sources */,
 				114333FF234B3E0700BFF775 /* CopyGeneratorTests.swift in Sources */,
 				119DD0A72344E7DF00E1E62D /* Field+Equatable.swift in Sources */,
+				11039C01234E885D0022EE33 /* testLensGeneratorMultipleFiles.1.swift in Sources */,
 				11039BFA234E865F0022EE33 /* LensVisitorTests.swift in Sources */,
 				119DD0A02344E3F100E1E62D /* ImportVisitorTests.swift in Sources */,
 				111F8519234DD545003FE646 /* testCopyGeneratorMultipleFiles.1.swift in Sources */,
 				11175E862346310800F26788 /* Snapshotting+Codegen.swift in Sources */,
+				11039BFE234E881C0022EE33 /* LensGeneratorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/bow-meta.xcodeproj/project.pbxproj
+++ b/bow-meta.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		11039BF7234E845B0022EE33 /* LensVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11039BF6234E845B0022EE33 /* LensVisitor.swift */; };
+		11039BFA234E865F0022EE33 /* LensVisitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11039BF8234E86590022EE33 /* LensVisitorTests.swift */; };
 		11175E8023462ED000F26788 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 11175E7F23462ED000F26788 /* SnapshotTesting */; };
 		11175E862346310800F26788 /* Snapshotting+Codegen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11175E84234630FD00F26788 /* Snapshotting+Codegen.swift */; };
 		111F8501234DCABB003FE646 /* CopyVisitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111F84FF234DCA98003FE646 /* CopyVisitorTests.swift */; };
@@ -74,6 +76,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		11039BF6234E845B0022EE33 /* LensVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LensVisitor.swift; sourceTree = "<group>"; };
+		11039BF8234E86590022EE33 /* LensVisitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LensVisitorTests.swift; sourceTree = "<group>"; };
 		11175E84234630FD00F26788 /* Snapshotting+Codegen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Snapshotting+Codegen.swift"; sourceTree = "<group>"; };
 		111F84FF234DCA98003FE646 /* CopyVisitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyVisitorTests.swift; sourceTree = "<group>"; };
 		111F8502234DCDBB003FE646 /* IsoVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IsoVisitor.swift; sourceTree = "<group>"; };
@@ -237,6 +241,7 @@
 				113746E52343A4ED00D9C1AD /* FieldVisitor.swift */,
 				113746E32343A47D00D9C1AD /* ImportVisitor.swift */,
 				111F8502234DCDBB003FE646 /* IsoVisitor.swift */,
+				11039BF6234E845B0022EE33 /* LensVisitor.swift */,
 			);
 			path = Visitors;
 			sourceTree = "<group>";
@@ -367,6 +372,7 @@
 				119DD0A12344E5BC00E1E62D /* FieldVisitorTests.swift */,
 				119DD09E2344E3E600E1E62D /* ImportVisitorTests.swift */,
 				111F8506234DD16E003FE646 /* IsoVisitorTests.swift */,
+				11039BF8234E86590022EE33 /* LensVisitorTests.swift */,
 			);
 			path = Visitors;
 			sourceTree = "<group>";
@@ -580,6 +586,7 @@
 				11433423234B50E200BFF775 /* CopyGenerator.swift in Sources */,
 				113746E82343A51A00D9C1AD /* ComputedPropertyVisitor.swift in Sources */,
 				11433417234B468D00BFF775 /* CodeGenerator.swift in Sources */,
+				11039BF7234E845B0022EE33 /* LensVisitor.swift in Sources */,
 				11433415234B45FF00BFF775 /* MacFileSystem.swift in Sources */,
 				113746E62343A4ED00D9C1AD /* FieldVisitor.swift in Sources */,
 				1143341F234B4F3700BFF775 /* Kleisli.swift in Sources */,
@@ -610,6 +617,7 @@
 				111F850D234DD2D6003FE646 /* IsoGeneratorTests.swift in Sources */,
 				114333FF234B3E0700BFF775 /* CopyGeneratorTests.swift in Sources */,
 				119DD0A72344E7DF00E1E62D /* Field+Equatable.swift in Sources */,
+				11039BFA234E865F0022EE33 /* LensVisitorTests.swift in Sources */,
 				119DD0A02344E3F100E1E62D /* ImportVisitorTests.swift in Sources */,
 				111F8519234DD545003FE646 /* testCopyGeneratorMultipleFiles.1.swift in Sources */,
 				11175E862346310800F26788 /* Snapshotting+Codegen.swift in Sources */,


### PR DESCRIPTION
## Issues

- Closes #6

## Goal

Generate Lenses for every field in a struct.

## Implementation details

A new visitor is created to visit `struct` declarations, extract their fields and create an extension to add a static computed property containing the lens for each one of them.

A new generator is created using this visitor and passing a default set of imports (`BowOptics` need to be imported in the generated code).

## Testing details

Generated code is tested using Snapshot testing and the generated output is put back into the project to guarantee its compilation.