### PR TITLE
Generate Optional

### DIFF
--- a/Sources/Meta/Generators/Environments/OptionalGenerator.swift
+++ b/Sources/Meta/Generators/Environments/OptionalGenerator.swift
@@ -1,0 +1,17 @@
+public class OptionalGenerator {
+    public init() {}
+}
+
+extension OptionalGenerator: HasFileSystem {
+    public var fileSystem: FileSystem {
+        MacFileSystem()
+    }
+}
+
+extension OptionalGenerator: HasCodeGenerator {
+    public var generator: CodeGenerator {
+        SwiftSyntaxGenerator(visitor: OptionalVisitor(),
+                             requiredImports: Set(["import Bow",
+                                                   "import BowOptics"]))
+    }
+}

--- a/Sources/Meta/Visitors/OptionalVisitor.swift
+++ b/Sources/Meta/Visitors/OptionalVisitor.swift
@@ -1,0 +1,62 @@
+import SwiftSyntax
+
+public class OptionalVisitor: SyntaxVisitor, CodegenVisitor {
+    private(set) public var generatedCode: String = ""
+    
+    override public func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+        let structName = node.identifier.description.trimmingCharacters(in: .whitespacesAndNewlines)
+        let fields = node.fields.filter(isOptionalType)
+        
+        if fields.count > 0 {
+            let optionalsCode = generateOptionals(for: fields, structName: structName)
+            
+            let code = """
+            extension \(structName) {
+            \(optionalsCode)
+            }
+            
+            """
+            print(code, to: &generatedCode)
+        }
+        
+        return .skipChildren
+    }
+    
+    private func isOptionalType(_ field: Field) -> Bool {
+        return field.type.hasSuffix("?") ||
+            field.type.hasPrefix("Option<")
+    }
+    
+    private func generateOptionals(for fields: [Field], structName: String) -> String {
+        fields.map { field in self.generateOptional(field, structName: structName) }.joined(separator: "\n\n")
+    }
+    
+    private func generateOptional(_ field: Field, structName: String) -> String {
+        let value = structName.lowercased()
+        let optionField = field.type.hasSuffix("?") ?
+            "\(value).\(field.name).toOption()" :
+            "\(value).\(field.name)"
+        return """
+            static var \(field.name)Optional: Optional<\(structName), \(field.type.nonOptional)> {
+                Optional(set: { $0.copy(with\(field.name.capitalized): .some($1)) },
+                         getOrModify: { \(value) in
+                             \(optionField).fold(
+                                 { Either.left(\(value)) },
+                                 Either.right)
+                         })
+            }
+        """
+    }
+}
+
+fileprivate extension String {
+    var nonOptional: String {
+        if self.hasSuffix("?") {
+            return String(self.dropLast())
+        } else if self.hasPrefix("Option<") {
+            return String(self.replacingOccurrences(of: "Option<", with: "").dropLast())
+        } else {
+            return self
+        }
+    }
+}

--- a/Sources/OpticsGenerator/main.swift
+++ b/Sources/OpticsGenerator/main.swift
@@ -44,6 +44,10 @@ func generateLens(_ input: URL, _ output: URL) -> Task<Void> {
     generate(input, output, "LensGeneration.swift", LensGenerator())
 }
 
+func generateOptional(_ input: URL, _ output: URL) -> Task<Void> {
+    generate(input, output, "OptionalGeneration.swift", OptionalGenerator())
+}
+
 func main() -> Task<Void> {
     let input = Task<URL>.var()
     let output = Task<URL>.var()
@@ -53,6 +57,7 @@ func main() -> Task<Void> {
                         |<-generateCopy(input.get, output.get),
                         |<-generateIso(input.get, output.get),
                         |<-generateLens(input.get, output.get),
+                        |<-generateOptional(input.get, output.get),
         yield:())^
 }
 

--- a/Tests/MetaTests/Extensions/Snapshotting+Codegen.swift
+++ b/Tests/MetaTests/Extensions/Snapshotting+Codegen.swift
@@ -19,6 +19,8 @@ extension Snapshotting where Value == URL, Format == String {
     
     static let lens: Snapshotting<URL, String> = .generatedCode(visitor: LensVisitor())
     
+    static let optional: Snapshotting<URL, String> = .generatedCode(visitor: OptionalVisitor())
+    
     static func generatedCode<D: CodegenDependencies>(using environment: D) -> Snapshotting<URL, String> {
         var strategy = Snapshotting<String, String>.lines.pullback { (url: URL) -> String in
             try! generateCode(forFilesIn: url.path)

--- a/Tests/MetaTests/Extensions/URL+Paths.swift
+++ b/Tests/MetaTests/Extensions/URL+Paths.swift
@@ -14,6 +14,7 @@ extension URL {
     enum File: String {
         case article = "Article.swift"
         case author = "Author.swift"
+        case company = "Subfolder/Company.swift"
     }
     
     var fixtures: URL { appendingPathComponent("Fixtures") }

--- a/Tests/MetaTests/Generators/OptionalGeneratorTests.swift
+++ b/Tests/MetaTests/Generators/OptionalGeneratorTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+import SnapshotTesting
+import Meta
+
+class OptionalGeneratorTests: XCTestCase {
+    func testOptionalGeneratorMultipleFiles() {
+        assertSnapshot(matching: URL.meta.fixtures, as: .generatedCode(using: OptionalGenerator()))
+    }
+}

--- a/Tests/MetaTests/Generators/__Snapshots__/OptionalGeneratorTests/testOptionalGeneratorMultipleFiles.1.swift
+++ b/Tests/MetaTests/Generators/__Snapshots__/OptionalGeneratorTests/testOptionalGeneratorMultipleFiles.1.swift
@@ -1,0 +1,33 @@
+import Bow
+import BowOptics
+import Foundation
+
+
+// MARK: - Generated from file Company.swift
+
+extension Company {
+    static var ctoOptional: Optional<Company, Employee> {
+        Optional(set: { $0.copy(withCto: .some($1)) },
+                 getOrModify: { company in
+                     company.cto.fold(
+                         { Either.left(company) },
+                         Either.right)
+                 })
+    }
+}
+
+
+
+// MARK: - Generated from file Article.swift
+
+extension Article {
+    static var subtitleOptional: Optional<Article, String> {
+        Optional(set: { $0.copy(withSubtitle: .some($1)) },
+                 getOrModify: { article in
+                     article.subtitle.toOption().fold(
+                         { Either.left(article) },
+                         Either.right)
+                 })
+    }
+}
+

--- a/Tests/MetaTests/Visitors/OptionalVisitorTests.swift
+++ b/Tests/MetaTests/Visitors/OptionalVisitorTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+import Meta
+import SnapshotTesting
+
+class OptionalVisitorTests: XCTestCase {
+    func testGeneratedOptional() {
+        assertSnapshot(matching: URL.meta.fixtures.file(.article), as: .optional)
+    }
+    
+    func testGeneratedOptionalForBowOption() {
+        assertSnapshot(matching: URL.meta.fixtures.file(.company), as: .optional)
+    }
+}

--- a/Tests/MetaTests/Visitors/__Snapshots__/OptionalVisitorTests/testGeneratedOptional.1.txt
+++ b/Tests/MetaTests/Visitors/__Snapshots__/OptionalVisitorTests/testGeneratedOptional.1.txt
@@ -1,0 +1,11 @@
+extension Article {
+    static var subtitleOptional: Optional<Article, String> {
+        Optional(set: { $0.copy(withSubtitle: .some($1)) },
+                 getOrModify: { article in
+                     article.subtitle.toOption().fold(
+                         { Either.left(article) },
+                         Either.right)
+                 })
+    }
+}
+

--- a/Tests/MetaTests/Visitors/__Snapshots__/OptionalVisitorTests/testGeneratedOptionalForBowOption.1.txt
+++ b/Tests/MetaTests/Visitors/__Snapshots__/OptionalVisitorTests/testGeneratedOptionalForBowOption.1.txt
@@ -1,0 +1,22 @@
+extension Article {
+    static var subtitleOptional: Optional<Article, String> {
+        Optional(set: { $0.copy(withSubtitle: .some($1)) },
+                 getOrModify: { article in
+                     article.subtitle.toOption().fold(
+                         { Either.left(article) },
+                         Either.right)
+                 })
+    }
+}
+
+extension Company {
+    static var ctoOptional: Optional<Company, Employee> {
+        Optional(set: { $0.copy(withCto: .some($1)) },
+                 getOrModify: { company in
+                     company.cto.fold(
+                         { Either.left(company) },
+                         Either.right)
+                 })
+    }
+}
+

--- a/bow-meta.xcodeproj/project.pbxproj
+++ b/bow-meta.xcodeproj/project.pbxproj
@@ -46,6 +46,8 @@
 		11433433234B75C600BFF775 /* OpticsGenerator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1143342A234B75C600BFF775 /* OpticsGenerator.framework */; };
 		1143343A234B75C600BFF775 /* OpticsGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 1143342C234B75C600BFF775 /* OpticsGenerator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1143344B234B766000BFF775 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11433444234B763100BFF775 /* main.swift */; };
+		116867F8234F467800976262 /* OptionalVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116867F7234F467800976262 /* OptionalVisitor.swift */; };
+		116867FB234F4AB800976262 /* OptionalVisitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116867F9234F4A6F00976262 /* OptionalVisitorTests.swift */; };
 		119DD0982344E27400E1E62D /* Article.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119DD0962344E27000E1E62D /* Article.swift */; };
 		119DD09B2344E35400E1E62D /* Author.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119DD0992344E35200E1E62D /* Author.swift */; };
 		119DD0A02344E3F100E1E62D /* ImportVisitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119DD09E2344E3E600E1E62D /* ImportVisitorTests.swift */; };
@@ -120,6 +122,8 @@
 		11433432234B75C600BFF775 /* OpticsGeneratorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpticsGeneratorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		11433439234B75C600BFF775 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		11433444234B763100BFF775 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		116867F7234F467800976262 /* OptionalVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalVisitor.swift; sourceTree = "<group>"; };
+		116867F9234F4A6F00976262 /* OptionalVisitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalVisitorTests.swift; sourceTree = "<group>"; };
 		119DD0962344E27000E1E62D /* Article.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Article.swift; sourceTree = "<group>"; };
 		119DD0992344E35200E1E62D /* Author.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Author.swift; sourceTree = "<group>"; };
 		119DD09E2344E3E600E1E62D /* ImportVisitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportVisitorTests.swift; sourceTree = "<group>"; };
@@ -256,6 +260,7 @@
 				113746E32343A47D00D9C1AD /* ImportVisitor.swift */,
 				111F8502234DCDBB003FE646 /* IsoVisitor.swift */,
 				11039BF6234E845B0022EE33 /* LensVisitor.swift */,
+				116867F7234F467800976262 /* OptionalVisitor.swift */,
 			);
 			path = Visitors;
 			sourceTree = "<group>";
@@ -390,6 +395,7 @@
 				119DD09E2344E3E600E1E62D /* ImportVisitorTests.swift */,
 				111F8506234DD16E003FE646 /* IsoVisitorTests.swift */,
 				11039BF8234E86590022EE33 /* LensVisitorTests.swift */,
+				116867F9234F4A6F00976262 /* OptionalVisitorTests.swift */,
 			);
 			path = Visitors;
 			sourceTree = "<group>";
@@ -616,6 +622,7 @@
 				111F8503234DCDBB003FE646 /* IsoVisitor.swift in Sources */,
 				114333F8234B355800BFF775 /* GenerateCode.swift in Sources */,
 				113746EA2343A56D00D9C1AD /* CopyVisitor.swift in Sources */,
+				116867F8234F467800976262 /* OptionalVisitor.swift in Sources */,
 				111F850A234DD28D003FE646 /* IsoGenerator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -634,6 +641,7 @@
 				1143340B234B401100BFF775 /* Company.swift in Sources */,
 				111F850D234DD2D6003FE646 /* IsoGeneratorTests.swift in Sources */,
 				114333FF234B3E0700BFF775 /* CopyGeneratorTests.swift in Sources */,
+				116867FB234F4AB800976262 /* OptionalVisitorTests.swift in Sources */,
 				119DD0A72344E7DF00E1E62D /* Field+Equatable.swift in Sources */,
 				11039C01234E885D0022EE33 /* testLensGeneratorMultipleFiles.1.swift in Sources */,
 				11039BFA234E865F0022EE33 /* LensVisitorTests.swift in Sources */,

--- a/bow-meta.xcodeproj/project.pbxproj
+++ b/bow-meta.xcodeproj/project.pbxproj
@@ -48,6 +48,9 @@
 		1143344B234B766000BFF775 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11433444234B763100BFF775 /* main.swift */; };
 		116867F8234F467800976262 /* OptionalVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116867F7234F467800976262 /* OptionalVisitor.swift */; };
 		116867FB234F4AB800976262 /* OptionalVisitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116867F9234F4A6F00976262 /* OptionalVisitorTests.swift */; };
+		116867FD234F4D2D00976262 /* OptionalGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116867FC234F4D2D00976262 /* OptionalGenerator.swift */; };
+		116867FF234F4D9500976262 /* OptionalGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116867FE234F4D9500976262 /* OptionalGeneratorTests.swift */; };
+		11686802234F4E4800976262 /* testOptionalGeneratorMultipleFiles.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11686801234F4E4800976262 /* testOptionalGeneratorMultipleFiles.1.swift */; };
 		119DD0982344E27400E1E62D /* Article.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119DD0962344E27000E1E62D /* Article.swift */; };
 		119DD09B2344E35400E1E62D /* Author.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119DD0992344E35200E1E62D /* Author.swift */; };
 		119DD0A02344E3F100E1E62D /* ImportVisitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119DD09E2344E3E600E1E62D /* ImportVisitorTests.swift */; };
@@ -124,6 +127,9 @@
 		11433444234B763100BFF775 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		116867F7234F467800976262 /* OptionalVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalVisitor.swift; sourceTree = "<group>"; };
 		116867F9234F4A6F00976262 /* OptionalVisitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalVisitorTests.swift; sourceTree = "<group>"; };
+		116867FC234F4D2D00976262 /* OptionalGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalGenerator.swift; sourceTree = "<group>"; };
+		116867FE234F4D9500976262 /* OptionalGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalGeneratorTests.swift; sourceTree = "<group>"; };
+		11686801234F4E4800976262 /* testOptionalGeneratorMultipleFiles.1.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = testOptionalGeneratorMultipleFiles.1.swift; sourceTree = "<group>"; };
 		119DD0962344E27000E1E62D /* Article.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Article.swift; sourceTree = "<group>"; };
 		119DD0992344E35200E1E62D /* Author.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Author.swift; sourceTree = "<group>"; };
 		119DD09E2344E3E600E1E62D /* ImportVisitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportVisitorTests.swift; sourceTree = "<group>"; };
@@ -283,6 +289,7 @@
 				114333FD234B3DC700BFF775 /* CopyGeneratorTests.swift */,
 				111F850B234DD2BE003FE646 /* IsoGeneratorTests.swift */,
 				11039BFD234E881C0022EE33 /* LensGeneratorTests.swift */,
+				116867FE234F4D9500976262 /* OptionalGeneratorTests.swift */,
 			);
 			path = Generators;
 			sourceTree = "<group>";
@@ -299,9 +306,10 @@
 		11433402234B3EAF00BFF775 /* __Snapshots__ */ = {
 			isa = PBXGroup;
 			children = (
-				11039BFF234E885D0022EE33 /* LensGeneratorTests */,
-				111F850E234DD338003FE646 /* IsoGeneratorTests */,
 				11433403234B3EAF00BFF775 /* CopyGeneratorTests */,
+				111F850E234DD338003FE646 /* IsoGeneratorTests */,
+				11039BFF234E885D0022EE33 /* LensGeneratorTests */,
+				11686800234F4E4800976262 /* OptionalGeneratorTests */,
 			);
 			path = __Snapshots__;
 			sourceTree = "<group>";
@@ -348,6 +356,7 @@
 				11433422234B50E200BFF775 /* CopyGenerator.swift */,
 				111F8509234DD28D003FE646 /* IsoGenerator.swift */,
 				11039BFB234E87DC0022EE33 /* LensGenerator.swift */,
+				116867FC234F4D2D00976262 /* OptionalGenerator.swift */,
 			);
 			path = Environments;
 			sourceTree = "<group>";
@@ -375,6 +384,14 @@
 			children = (
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		11686800234F4E4800976262 /* OptionalGeneratorTests */ = {
+			isa = PBXGroup;
+			children = (
+				11686801234F4E4800976262 /* testOptionalGeneratorMultipleFiles.1.swift */,
+			);
+			path = OptionalGeneratorTests;
 			sourceTree = "<group>";
 		};
 		119DD0952344E26000E1E62D /* Fixtures */ = {
@@ -620,6 +637,7 @@
 				1143341D234B4B4600BFF775 /* SwiftSyntaxGenerator.swift in Sources */,
 				113746E42343A47D00D9C1AD /* ImportVisitor.swift in Sources */,
 				111F8503234DCDBB003FE646 /* IsoVisitor.swift in Sources */,
+				116867FD234F4D2D00976262 /* OptionalGenerator.swift in Sources */,
 				114333F8234B355800BFF775 /* GenerateCode.swift in Sources */,
 				113746EA2343A56D00D9C1AD /* CopyVisitor.swift in Sources */,
 				116867F8234F467800976262 /* OptionalVisitor.swift in Sources */,
@@ -637,6 +655,7 @@
 				111F8508234DD1BF003FE646 /* IsoVisitorTests.swift in Sources */,
 				119DD0982344E27400E1E62D /* Article.swift in Sources */,
 				119DD0A32344E5C100E1E62D /* FieldVisitorTests.swift in Sources */,
+				116867FF234F4D9500976262 /* OptionalGeneratorTests.swift in Sources */,
 				111F8501234DCABB003FE646 /* CopyVisitorTests.swift in Sources */,
 				1143340B234B401100BFF775 /* Company.swift in Sources */,
 				111F850D234DD2D6003FE646 /* IsoGeneratorTests.swift in Sources */,
@@ -646,6 +665,7 @@
 				11039C01234E885D0022EE33 /* testLensGeneratorMultipleFiles.1.swift in Sources */,
 				11039BFA234E865F0022EE33 /* LensVisitorTests.swift in Sources */,
 				119DD0A02344E3F100E1E62D /* ImportVisitorTests.swift in Sources */,
+				11686802234F4E4800976262 /* testOptionalGeneratorMultipleFiles.1.swift in Sources */,
 				111F8519234DD545003FE646 /* testCopyGeneratorMultipleFiles.1.swift in Sources */,
 				11175E862346310800F26788 /* Snapshotting+Codegen.swift in Sources */,
 				11039BFE234E881C0022EE33 /* LensGeneratorTests.swift in Sources */,


### PR DESCRIPTION
## Issues

- Closes #7

## Goal

Generate Optionals for every optional field in a struct.

## Implementation details

A new visitor is created to visit `struct` declarations, extract their optional fields and create an extension to add a static computed property containing the Optional for each one of them.

A new generator is created using this visitor and passing a default set of imports (`Bow` and `BowOptics` need to be imported in the generated code).

## Testing details

Generated code is tested using Snapshot testing and the generated output is put back into the project to guarantee its compilation.