### PR TITLE
Generate Traversals

### DIFF
--- a/Sources/Meta/Generators/Environments/TraversalGenerator.swift
+++ b/Sources/Meta/Generators/Environments/TraversalGenerator.swift
@@ -1,0 +1,16 @@
+public class TraversalGenerator {
+    public init() {}
+}
+
+extension TraversalGenerator: HasFileSystem {
+    public var fileSystem: FileSystem {
+        MacFileSystem()
+    }
+}
+
+extension TraversalGenerator: HasCodeGenerator {
+    public var generator: CodeGenerator {
+        SwiftSyntaxGenerator(visitor: TraversalVisitor(),
+                             requiredImports: Set(["import BowOptics"]))
+    }
+}

--- a/Sources/Meta/Visitors/TraversalVisitor.swift
+++ b/Sources/Meta/Visitors/TraversalVisitor.swift
@@ -1,0 +1,62 @@
+import SwiftSyntax
+
+public class TraversalVisitor: SyntaxVisitor, CodegenVisitor {
+    private(set) public var generatedCode: String = ""
+    
+    override public func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+        let structName = node.identifier.description.trimmingCharacters(in: .whitespacesAndNewlines)
+        let fields = node.fields.filter(isArrayType)
+        
+        if fields.count > 0 {
+            let traversalsCode = generateTraversals(for: fields, structName: structName)
+            
+            let code = """
+            extension \(structName) {
+            \(traversalsCode)
+            }
+            
+            """
+            print(code, to: &generatedCode)
+        }
+        
+        return .skipChildren
+    }
+    
+    private func isArrayType(_ field: Field) -> Bool {
+        return field.type.hasPrefix("[") ||
+            field.type.hasPrefix("Array<") ||
+            field.type.hasPrefix("ArrayK<") ||
+            field.type.hasPrefix("NEA<") ||
+            field.type.hasPrefix("NonEmptyArray<")
+    }
+    
+    private func generateTraversals(for fields: [Field], structName: String) -> String {
+        fields.map { field in self.generateTraversal(field, structName: structName) }.joined(separator: "\n\n")
+    }
+    
+    private func generateTraversal(_ field: Field, structName: String) -> String {
+        """
+            static var \(field.name)Traversal: Traversal<\(structName), \(field.type.nonArray)> {
+                \(field.name)Lens + \(field.type).traversal
+            }
+        """
+    }
+}
+
+fileprivate extension String {
+    var nonArray: String {
+        if hasPrefix("[") {
+            return String(dropFirst().dropLast())
+        } else if hasPrefix("Array<") {
+            return String(replacingOccurrences(of: "Array<", with: "").dropLast())
+        } else if hasPrefix("ArrayK<") {
+            return String(replacingOccurrences(of: "ArrayK<", with: "").dropLast())
+        } else if hasPrefix("NEA<") {
+            return String(replacingOccurrences(of: "NEA<", with: "").dropLast())
+        } else if hasPrefix("NonEmptyArray<") {
+            return String(replacingOccurrences(of: "NonEmptyArray<", with: "").dropLast())
+        } else {
+            return self
+        }
+    }
+}

--- a/Sources/OpticsGenerator/main.swift
+++ b/Sources/OpticsGenerator/main.swift
@@ -48,6 +48,10 @@ func generateOptional(_ input: URL, _ output: URL) -> Task<Void> {
     generate(input, output, "OptionalGeneration.swift", OptionalGenerator())
 }
 
+func generateTraversal(_ input: URL, _ output: URL) -> Task<Void> {
+    generate(input, output, "TraversalGeneration.swift", TraversalGenerator())
+}
+
 func main() -> Task<Void> {
     let input = Task<URL>.var()
     let output = Task<URL>.var()
@@ -58,6 +62,7 @@ func main() -> Task<Void> {
                         |<-generateIso(input.get, output.get),
                         |<-generateLens(input.get, output.get),
                         |<-generateOptional(input.get, output.get),
+                        |<-generateTraversal(input.get, output.get),
         yield:())^
 }
 

--- a/Tests/MetaTests/Extensions/Snapshotting+Codegen.swift
+++ b/Tests/MetaTests/Extensions/Snapshotting+Codegen.swift
@@ -21,6 +21,8 @@ extension Snapshotting where Value == URL, Format == String {
     
     static let optional: Snapshotting<URL, String> = .generatedCode(visitor: OptionalVisitor())
     
+    static let traversal: Snapshotting<URL, String> = .generatedCode(visitor: TraversalVisitor())
+    
     static func generatedCode<D: CodegenDependencies>(using environment: D) -> Snapshotting<URL, String> {
         var strategy = Snapshotting<String, String>.lines.pullback { (url: URL) -> String in
             try! generateCode(forFilesIn: url.path)

--- a/Tests/MetaTests/Fixtures/Author.swift
+++ b/Tests/MetaTests/Fixtures/Author.swift
@@ -7,7 +7,7 @@ enum SocialNetwork {
 
 struct Author {
     let name: String
-    let social: [SocialNetwork]
+    let social: Array<SocialNetwork>
     
     var hasTwitter: Bool {
         social.map { item in

--- a/Tests/MetaTests/Fixtures/Subfolder/Company.swift
+++ b/Tests/MetaTests/Fixtures/Subfolder/Company.swift
@@ -8,4 +8,6 @@ struct Company {
 
 struct Employee {
     let name: String
+    let phones: NEA<String>
+    let emails: NonEmptyArray<String>
 }

--- a/Tests/MetaTests/Generators/TraversalGeneratorTests.swift
+++ b/Tests/MetaTests/Generators/TraversalGeneratorTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+import SnapshotTesting
+import Meta
+
+class TraversalGeneratorTests: XCTestCase {
+    func testTraversalGeneratorMultipleFiles() {
+        assertSnapshot(matching: URL.meta.fixtures, as: .generatedCode(using: TraversalGenerator()))
+    }
+}

--- a/Tests/MetaTests/Generators/__Snapshots__/CopyGeneratorTests/testCopyGeneratorMultipleFiles.1.swift
+++ b/Tests/MetaTests/Generators/__Snapshots__/CopyGeneratorTests/testCopyGeneratorMultipleFiles.1.swift
@@ -15,8 +15,12 @@ extension Company {
 }
 
 extension Employee {
-    func copy(withName name: String? = nil) -> Employee {
-        Employee(name: name ?? self.name)
+    func copy(withName name: String? = nil,
+			  withPhones phones: NEA<String>? = nil,
+			  withEmails emails: NonEmptyArray<String>? = nil) -> Employee {
+        Employee(name: name ?? self.name,
+			phones: phones ?? self.phones,
+			emails: emails ?? self.emails)
     }
 }
 
@@ -25,7 +29,7 @@ extension Employee {
 
 extension Author {
     func copy(withName name: String? = nil,
-			  withSocial social: [SocialNetwork]? = nil) -> Author {
+			  withSocial social: Array<SocialNetwork>? = nil) -> Author {
         Author(name: name ?? self.name,
 			social: social ?? self.social)
     }

--- a/Tests/MetaTests/Generators/__Snapshots__/IsoGeneratorTests/testIsoGeneratorMultipleFiles.1.swift
+++ b/Tests/MetaTests/Generators/__Snapshots__/IsoGeneratorTests/testIsoGeneratorMultipleFiles.1.swift
@@ -12,8 +12,8 @@ extension Company {
 }
 
 extension Employee {
-    static var iso: Iso<Employee, (String)> {
-        Iso(get: { employee in (employee.name) }, reverseGet: Employee.init)
+    static var iso: Iso<Employee, (String, NEA<String>, NonEmptyArray<String>)> {
+        Iso(get: { employee in (employee.name, employee.phones, employee.emails) }, reverseGet: Employee.init)
     }
 }
 
@@ -21,7 +21,7 @@ extension Employee {
 // MARK: - Generated from file Author.swift
 
 extension Author {
-    static var iso: Iso<Author, (String, [SocialNetwork])> {
+    static var iso: Iso<Author, (String, Array<SocialNetwork>)> {
         Iso(get: { author in (author.name, author.social) }, reverseGet: Author.init)
     }
 }

--- a/Tests/MetaTests/Generators/__Snapshots__/LensGeneratorTests/testLensGeneratorMultipleFiles.1.swift
+++ b/Tests/MetaTests/Generators/__Snapshots__/LensGeneratorTests/testLensGeneratorMultipleFiles.1.swift
@@ -27,6 +27,16 @@ extension Employee {
         Lens(get: { $0.name },
              set: { $0.copy(withName: $1) })
     }
+
+    static var phonesLens: Lens<Employee, NEA<String>> {
+        Lens(get: { $0.phones },
+             set: { $0.copy(withPhones: $1) })
+    }
+
+    static var emailsLens: Lens<Employee, NonEmptyArray<String>> {
+        Lens(get: { $0.emails },
+             set: { $0.copy(withEmails: $1) })
+    }
 }
 
 
@@ -38,7 +48,7 @@ extension Author {
              set: { $0.copy(withName: $1) })
     }
 
-    static var socialLens: Lens<Author, [SocialNetwork]> {
+    static var socialLens: Lens<Author, Array<SocialNetwork>> {
         Lens(get: { $0.social },
              set: { $0.copy(withSocial: $1) })
     }

--- a/Tests/MetaTests/Generators/__Snapshots__/TraversalGeneratorTests/testTraversalGeneratorMultipleFiles.1.swift
+++ b/Tests/MetaTests/Generators/__Snapshots__/TraversalGeneratorTests/testTraversalGeneratorMultipleFiles.1.swift
@@ -11,12 +11,22 @@ extension Company {
     }
 }
 
+extension Employee {
+    static var phonesTraversal: Traversal<Employee, String> {
+        phonesLens + NEA<String>.traversal
+    }
+
+    static var emailsTraversal: Traversal<Employee, String> {
+        emailsLens + NonEmptyArray<String>.traversal
+    }
+}
+
 
 // MARK: - Generated from file Author.swift
 
 extension Author {
     static var socialTraversal: Traversal<Author, SocialNetwork> {
-        socialLens + [SocialNetwork].traversal
+        socialLens + Array<SocialNetwork>.traversal
     }
 }
 

--- a/Tests/MetaTests/Generators/__Snapshots__/TraversalGeneratorTests/testTraversalGeneratorMultipleFiles.1.swift
+++ b/Tests/MetaTests/Generators/__Snapshots__/TraversalGeneratorTests/testTraversalGeneratorMultipleFiles.1.swift
@@ -1,0 +1,31 @@
+import Bow
+import BowOptics
+import Foundation
+
+
+// MARK: - Generated from file Company.swift
+
+extension Company {
+    static var employeesTraversal: Traversal<Company, Employee> {
+        employeesLens + ArrayK<Employee>.traversal
+    }
+}
+
+
+// MARK: - Generated from file Author.swift
+
+extension Author {
+    static var socialTraversal: Traversal<Author, SocialNetwork> {
+        socialLens + [SocialNetwork].traversal
+    }
+}
+
+
+// MARK: - Generated from file Article.swift
+
+extension Blog {
+    static var articlesTraversal: Traversal<Blog, Article> {
+        articlesLens + [Article].traversal
+    }
+}
+

--- a/Tests/MetaTests/Visitors/FieldVisitorTests.swift
+++ b/Tests/MetaTests/Visitors/FieldVisitorTests.swift
@@ -9,7 +9,7 @@ class FieldVisitorTests: XCTestCase {
         ast.walk(visitor)
         
         let expected = [Field(name: "name", type: "String"),
-                        Field(name: "social", type: "[SocialNetwork]")]
+                        Field(name: "social", type: "Array<SocialNetwork>")]
         
         XCTAssertTrue(visitor.fields == expected)
     }

--- a/Tests/MetaTests/Visitors/TraversalVisitorTests.swift
+++ b/Tests/MetaTests/Visitors/TraversalVisitorTests.swift
@@ -7,7 +7,7 @@ class TraversalVisitorTests: XCTestCase {
         assertSnapshot(matching: URL.meta.fixtures.file(.article), as: .traversal)
     }
     
-    func testGeneratedTraversalForBowArrayK() {
+    func testGeneratedTraversalForBowArrayKandNEA() {
         assertSnapshot(matching: URL.meta.fixtures.file(.company), as: .traversal)
     }
 }

--- a/Tests/MetaTests/Visitors/TraversalVisitorTests.swift
+++ b/Tests/MetaTests/Visitors/TraversalVisitorTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+import Meta
+import SnapshotTesting
+
+class TraversalVisitorTests: XCTestCase {
+    func testGeneratedTraversal() {
+        assertSnapshot(matching: URL.meta.fixtures.file(.article), as: .traversal)
+    }
+    
+    func testGeneratedTraversalForBowArrayK() {
+        assertSnapshot(matching: URL.meta.fixtures.file(.company), as: .traversal)
+    }
+}

--- a/Tests/MetaTests/Visitors/__Snapshots__/TraversalVisitorTests/testGeneratedTraversal.1.txt
+++ b/Tests/MetaTests/Visitors/__Snapshots__/TraversalVisitorTests/testGeneratedTraversal.1.txt
@@ -1,0 +1,6 @@
+extension Blog {
+    static var articlesTraversal: Traversal<Blog, Article> {
+        articlesLens + [Article].traversal
+    }
+}
+

--- a/Tests/MetaTests/Visitors/__Snapshots__/TraversalVisitorTests/testGeneratedTraversalForBowArrayK.1.txt
+++ b/Tests/MetaTests/Visitors/__Snapshots__/TraversalVisitorTests/testGeneratedTraversalForBowArrayK.1.txt
@@ -1,0 +1,12 @@
+extension Blog {
+    static var articlesTraversal: Traversal<Blog, Article> {
+        articlesLens + [Article].traversal
+    }
+}
+
+extension Company {
+    static var employeesTraversal: Traversal<Company, Employee> {
+        employeesLens + ArrayK<Employee>.traversal
+    }
+}
+

--- a/Tests/MetaTests/Visitors/__Snapshots__/TraversalVisitorTests/testGeneratedTraversalForBowArrayKandNEA.1.txt
+++ b/Tests/MetaTests/Visitors/__Snapshots__/TraversalVisitorTests/testGeneratedTraversalForBowArrayKandNEA.1.txt
@@ -10,3 +10,13 @@ extension Company {
     }
 }
 
+extension Employee {
+    static var phonesTraversal: Traversal<Employee, String> {
+        phonesLens + NEA<String>.traversal
+    }
+
+    static var emailsTraversal: Traversal<Employee, String> {
+        emailsLens + NonEmptyArray<String>.traversal
+    }
+}
+

--- a/bow-meta.xcodeproj/project.pbxproj
+++ b/bow-meta.xcodeproj/project.pbxproj
@@ -51,11 +51,16 @@
 		116867FD234F4D2D00976262 /* OptionalGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116867FC234F4D2D00976262 /* OptionalGenerator.swift */; };
 		116867FF234F4D9500976262 /* OptionalGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116867FE234F4D9500976262 /* OptionalGeneratorTests.swift */; };
 		11686802234F4E4800976262 /* testOptionalGeneratorMultipleFiles.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11686801234F4E4800976262 /* testOptionalGeneratorMultipleFiles.1.swift */; };
+		11686805234F6AD500976262 /* TraversalVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11686803234F6AB300976262 /* TraversalVisitor.swift */; };
+		11686807234F6D4300976262 /* TraversalVisitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11686806234F6D4300976262 /* TraversalVisitorTests.swift */; };
 		119DD0982344E27400E1E62D /* Article.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119DD0962344E27000E1E62D /* Article.swift */; };
 		119DD09B2344E35400E1E62D /* Author.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119DD0992344E35200E1E62D /* Author.swift */; };
 		119DD0A02344E3F100E1E62D /* ImportVisitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119DD09E2344E3E600E1E62D /* ImportVisitorTests.swift */; };
 		119DD0A32344E5C100E1E62D /* FieldVisitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119DD0A12344E5BC00E1E62D /* FieldVisitorTests.swift */; };
 		119DD0A72344E7DF00E1E62D /* Field+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119DD0A52344E7D400E1E62D /* Field+Equatable.swift */; };
+		11F274C4234F6F2F00BC4CFB /* TraversalGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F274C3234F6F2F00BC4CFB /* TraversalGenerator.swift */; };
+		11F274C6234F6F5F00BC4CFB /* TraversalGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F274C5234F6F5F00BC4CFB /* TraversalGeneratorTests.swift */; };
+		11F274C9234F6FAA00BC4CFB /* testTraversalGeneratorMultipleFiles.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F274C8234F6FAA00BC4CFB /* testTraversalGeneratorMultipleFiles.1.swift */; };
 		8BFE7E3E234DE843003E97BF /* URL+Paths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFE7E3D234DE843003E97BF /* URL+Paths.swift */; };
 /* End PBXBuildFile section */
 
@@ -130,11 +135,16 @@
 		116867FC234F4D2D00976262 /* OptionalGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalGenerator.swift; sourceTree = "<group>"; };
 		116867FE234F4D9500976262 /* OptionalGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalGeneratorTests.swift; sourceTree = "<group>"; };
 		11686801234F4E4800976262 /* testOptionalGeneratorMultipleFiles.1.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = testOptionalGeneratorMultipleFiles.1.swift; sourceTree = "<group>"; };
+		11686803234F6AB300976262 /* TraversalVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraversalVisitor.swift; sourceTree = "<group>"; };
+		11686806234F6D4300976262 /* TraversalVisitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraversalVisitorTests.swift; sourceTree = "<group>"; };
 		119DD0962344E27000E1E62D /* Article.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Article.swift; sourceTree = "<group>"; };
 		119DD0992344E35200E1E62D /* Author.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Author.swift; sourceTree = "<group>"; };
 		119DD09E2344E3E600E1E62D /* ImportVisitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportVisitorTests.swift; sourceTree = "<group>"; };
 		119DD0A12344E5BC00E1E62D /* FieldVisitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldVisitorTests.swift; sourceTree = "<group>"; };
 		119DD0A52344E7D400E1E62D /* Field+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Field+Equatable.swift"; sourceTree = "<group>"; };
+		11F274C3234F6F2F00BC4CFB /* TraversalGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraversalGenerator.swift; sourceTree = "<group>"; };
+		11F274C5234F6F5F00BC4CFB /* TraversalGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraversalGeneratorTests.swift; sourceTree = "<group>"; };
+		11F274C8234F6FAA00BC4CFB /* testTraversalGeneratorMultipleFiles.1.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = testTraversalGeneratorMultipleFiles.1.swift; sourceTree = "<group>"; };
 		8BFE7E3D234DE843003E97BF /* URL+Paths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Paths.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -267,6 +277,7 @@
 				111F8502234DCDBB003FE646 /* IsoVisitor.swift */,
 				11039BF6234E845B0022EE33 /* LensVisitor.swift */,
 				116867F7234F467800976262 /* OptionalVisitor.swift */,
+				11686803234F6AB300976262 /* TraversalVisitor.swift */,
 			);
 			path = Visitors;
 			sourceTree = "<group>";
@@ -290,6 +301,7 @@
 				111F850B234DD2BE003FE646 /* IsoGeneratorTests.swift */,
 				11039BFD234E881C0022EE33 /* LensGeneratorTests.swift */,
 				116867FE234F4D9500976262 /* OptionalGeneratorTests.swift */,
+				11F274C5234F6F5F00BC4CFB /* TraversalGeneratorTests.swift */,
 			);
 			path = Generators;
 			sourceTree = "<group>";
@@ -310,6 +322,7 @@
 				111F850E234DD338003FE646 /* IsoGeneratorTests */,
 				11039BFF234E885D0022EE33 /* LensGeneratorTests */,
 				11686800234F4E4800976262 /* OptionalGeneratorTests */,
+				11F274C7234F6FAA00BC4CFB /* TraversalGeneratorTests */,
 			);
 			path = __Snapshots__;
 			sourceTree = "<group>";
@@ -357,6 +370,7 @@
 				111F8509234DD28D003FE646 /* IsoGenerator.swift */,
 				11039BFB234E87DC0022EE33 /* LensGenerator.swift */,
 				116867FC234F4D2D00976262 /* OptionalGenerator.swift */,
+				11F274C3234F6F2F00BC4CFB /* TraversalGenerator.swift */,
 			);
 			path = Environments;
 			sourceTree = "<group>";
@@ -413,6 +427,7 @@
 				111F8506234DD16E003FE646 /* IsoVisitorTests.swift */,
 				11039BF8234E86590022EE33 /* LensVisitorTests.swift */,
 				116867F9234F4A6F00976262 /* OptionalVisitorTests.swift */,
+				11686806234F6D4300976262 /* TraversalVisitorTests.swift */,
 			);
 			path = Visitors;
 			sourceTree = "<group>";
@@ -425,6 +440,14 @@
 				8BFE7E3D234DE843003E97BF /* URL+Paths.swift */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		11F274C7234F6FAA00BC4CFB /* TraversalGeneratorTests */ = {
+			isa = PBXGroup;
+			children = (
+				11F274C8234F6FAA00BC4CFB /* testTraversalGeneratorMultipleFiles.1.swift */,
+			);
+			path = TraversalGeneratorTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -632,6 +655,7 @@
 				113746E62343A4ED00D9C1AD /* FieldVisitor.swift in Sources */,
 				1143341F234B4F3700BFF775 /* Kleisli.swift in Sources */,
 				11433421234B4FAA00BFF775 /* IO.swift in Sources */,
+				11F274C4234F6F2F00BC4CFB /* TraversalGenerator.swift in Sources */,
 				114333F2234B2AF900BFF775 /* CodegenVisitor.swift in Sources */,
 				1143340F234B430C00BFF775 /* Set.swift in Sources */,
 				1143341D234B4B4600BFF775 /* SwiftSyntaxGenerator.swift in Sources */,
@@ -640,6 +664,7 @@
 				116867FD234F4D2D00976262 /* OptionalGenerator.swift in Sources */,
 				114333F8234B355800BFF775 /* GenerateCode.swift in Sources */,
 				113746EA2343A56D00D9C1AD /* CopyVisitor.swift in Sources */,
+				11686805234F6AD500976262 /* TraversalVisitor.swift in Sources */,
 				116867F8234F467800976262 /* OptionalVisitor.swift in Sources */,
 				111F850A234DD28D003FE646 /* IsoGenerator.swift in Sources */,
 			);
@@ -658,9 +683,12 @@
 				116867FF234F4D9500976262 /* OptionalGeneratorTests.swift in Sources */,
 				111F8501234DCABB003FE646 /* CopyVisitorTests.swift in Sources */,
 				1143340B234B401100BFF775 /* Company.swift in Sources */,
+				11F274C9234F6FAA00BC4CFB /* testTraversalGeneratorMultipleFiles.1.swift in Sources */,
+				11F274C6234F6F5F00BC4CFB /* TraversalGeneratorTests.swift in Sources */,
 				111F850D234DD2D6003FE646 /* IsoGeneratorTests.swift in Sources */,
 				114333FF234B3E0700BFF775 /* CopyGeneratorTests.swift in Sources */,
 				116867FB234F4AB800976262 /* OptionalVisitorTests.swift in Sources */,
+				11686807234F6D4300976262 /* TraversalVisitorTests.swift in Sources */,
 				119DD0A72344E7DF00E1E62D /* Field+Equatable.swift in Sources */,
 				11039C01234E885D0022EE33 /* testLensGeneratorMultipleFiles.1.swift in Sources */,
 				11039BFA234E865F0022EE33 /* LensVisitorTests.swift in Sources */,


### PR DESCRIPTION
## Issues

- Closes #8 

## Goal

Generate Traversals for every array field in a struct.

## Implementation details

A new visitor is created to visit `struct` declarations, extract their array fields and create an extension to add a static computed property containing the Traversal for each one of them.

A new generator is created using this visitor and passing a default set of imports (`BowOptics` need to be imported in the generated code).

## Testing details

Generated code is tested using Snapshot testing and the generated output is put back into the project to guarantee its compilation.