### PR TITLE
Generate Folds

### DIFF
--- a/Sources/Meta/Generators/Environments/FoldGenerator.swift
+++ b/Sources/Meta/Generators/Environments/FoldGenerator.swift
@@ -1,0 +1,16 @@
+public class FoldGenerator {
+    public init() {}
+}
+
+extension FoldGenerator: HasFileSystem {
+    public var fileSystem: FileSystem {
+        MacFileSystem()
+    }
+}
+
+extension FoldGenerator: HasCodeGenerator {
+    public var generator: CodeGenerator {
+        SwiftSyntaxGenerator(visitor: FoldVisitor(),
+                             requiredImports: Set(["import BowOptics"]))
+    }
+}

--- a/Sources/Meta/Visitors/FoldVisitor.swift
+++ b/Sources/Meta/Visitors/FoldVisitor.swift
@@ -1,0 +1,62 @@
+import SwiftSyntax
+
+public class FoldVisitor: SyntaxVisitor, CodegenVisitor {
+    private(set) public var generatedCode: String = ""
+    
+    override public func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+        let structName = node.identifier.description.trimmingCharacters(in: .whitespacesAndNewlines)
+        let fields = node.fields.filter(isArrayType)
+        
+        if fields.count > 0 {
+            let foldsCode = generateFolds(for: fields, structName: structName)
+            
+            let code = """
+            extension \(structName) {
+            \(foldsCode)
+            }
+            
+            """
+            print(code, to: &generatedCode)
+        }
+        
+        return .skipChildren
+    }
+    
+    private func isArrayType(_ field: Field) -> Bool {
+        return field.type.hasPrefix("[") ||
+            field.type.hasPrefix("Array<") ||
+            field.type.hasPrefix("ArrayK<") ||
+            field.type.hasPrefix("NEA<") ||
+            field.type.hasPrefix("NonEmptyArray<")
+    }
+    
+    private func generateFolds(for fields: [Field], structName: String) -> String {
+        fields.map { field in self.generateFold(field, structName: structName) }.joined(separator: "\n\n")
+    }
+    
+    private func generateFold(_ field: Field, structName: String) -> String {
+        """
+            static var \(field.name)Fold: Fold<\(structName), \(field.type.nonArray)> {
+                \(field.name)Lens + \(field.type).fold
+            }
+        """
+    }
+}
+
+fileprivate extension String {
+    var nonArray: String {
+        if hasPrefix("[") {
+            return String(dropFirst().dropLast())
+        } else if hasPrefix("Array<") {
+            return String(replacingOccurrences(of: "Array<", with: "").dropLast())
+        } else if hasPrefix("ArrayK<") {
+            return String(replacingOccurrences(of: "ArrayK<", with: "").dropLast())
+        } else if hasPrefix("NEA<") {
+            return String(replacingOccurrences(of: "NEA<", with: "").dropLast())
+        } else if hasPrefix("NonEmptyArray<") {
+            return String(replacingOccurrences(of: "NonEmptyArray<", with: "").dropLast())
+        } else {
+            return self
+        }
+    }
+}

--- a/Sources/Meta/Visitors/FoldVisitor.swift
+++ b/Sources/Meta/Visitors/FoldVisitor.swift
@@ -42,21 +42,3 @@ public class FoldVisitor: SyntaxVisitor, CodegenVisitor {
         """
     }
 }
-
-fileprivate extension String {
-    var nonArray: String {
-        if hasPrefix("[") {
-            return String(dropFirst().dropLast())
-        } else if hasPrefix("Array<") {
-            return String(replacingOccurrences(of: "Array<", with: "").dropLast())
-        } else if hasPrefix("ArrayK<") {
-            return String(replacingOccurrences(of: "ArrayK<", with: "").dropLast())
-        } else if hasPrefix("NEA<") {
-            return String(replacingOccurrences(of: "NEA<", with: "").dropLast())
-        } else if hasPrefix("NonEmptyArray<") {
-            return String(replacingOccurrences(of: "NonEmptyArray<", with: "").dropLast())
-        } else {
-            return self
-        }
-    }
-}

--- a/Sources/Meta/Visitors/TraversalVisitor.swift
+++ b/Sources/Meta/Visitors/TraversalVisitor.swift
@@ -42,21 +42,3 @@ public class TraversalVisitor: SyntaxVisitor, CodegenVisitor {
         """
     }
 }
-
-fileprivate extension String {
-    var nonArray: String {
-        if hasPrefix("[") {
-            return String(dropFirst().dropLast())
-        } else if hasPrefix("Array<") {
-            return String(replacingOccurrences(of: "Array<", with: "").dropLast())
-        } else if hasPrefix("ArrayK<") {
-            return String(replacingOccurrences(of: "ArrayK<", with: "").dropLast())
-        } else if hasPrefix("NEA<") {
-            return String(replacingOccurrences(of: "NEA<", with: "").dropLast())
-        } else if hasPrefix("NonEmptyArray<") {
-            return String(replacingOccurrences(of: "NonEmptyArray<", with: "").dropLast())
-        } else {
-            return self
-        }
-    }
-}

--- a/Sources/OpticsGenerator/main.swift
+++ b/Sources/OpticsGenerator/main.swift
@@ -52,6 +52,10 @@ func generateTraversal(_ input: URL, _ output: URL) -> Task<Void> {
     generate(input, output, "TraversalGeneration.swift", TraversalGenerator())
 }
 
+func generateFold(_ input: URL, _ output: URL) -> Task<Void> {
+    generate(input, output, "FoldGeneration.swift", FoldGenerator())
+}
+
 func main() -> Task<Void> {
     let input = Task<URL>.var()
     let output = Task<URL>.var()
@@ -63,6 +67,7 @@ func main() -> Task<Void> {
                         |<-generateLens(input.get, output.get),
                         |<-generateOptional(input.get, output.get),
                         |<-generateTraversal(input.get, output.get),
+                        |<-generateFold(input.get, output.get),
         yield:())^
 }
 

--- a/String+NoArray.swift
+++ b/String+NoArray.swift
@@ -1,0 +1,17 @@
+extension String {
+    var nonArray: String {
+        if hasPrefix("[") {
+            return String(dropFirst().dropLast())
+        } else if hasPrefix("Array<") {
+            return String(replacingOccurrences(of: "Array<", with: "").dropLast())
+        } else if hasPrefix("ArrayK<") {
+            return String(replacingOccurrences(of: "ArrayK<", with: "").dropLast())
+        } else if hasPrefix("NEA<") {
+            return String(replacingOccurrences(of: "NEA<", with: "").dropLast())
+        } else if hasPrefix("NonEmptyArray<") {
+            return String(replacingOccurrences(of: "NonEmptyArray<", with: "").dropLast())
+        } else {
+            return self
+        }
+    }
+}

--- a/Tests/MetaTests/Extensions/Snapshotting+Codegen.swift
+++ b/Tests/MetaTests/Extensions/Snapshotting+Codegen.swift
@@ -23,6 +23,8 @@ extension Snapshotting where Value == URL, Format == String {
     
     static let traversal: Snapshotting<URL, String> = .generatedCode(visitor: TraversalVisitor())
     
+    static let fold: Snapshotting<URL, String> = .generatedCode(visitor: FoldVisitor())
+    
     static func generatedCode<D: CodegenDependencies>(using environment: D) -> Snapshotting<URL, String> {
         var strategy = Snapshotting<String, String>.lines.pullback { (url: URL) -> String in
             try! generateCode(forFilesIn: url.path)

--- a/Tests/MetaTests/Generators/FoldGeneratorTests.swift
+++ b/Tests/MetaTests/Generators/FoldGeneratorTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+import SnapshotTesting
+import Meta
+
+class FoldGeneratorTests: XCTestCase {
+    func testFoldGeneratorMultipleFiles() {
+        assertSnapshot(matching: URL.meta.fixtures, as: .generatedCode(using: FoldGenerator()))
+    }
+}

--- a/Tests/MetaTests/Generators/__Snapshots__/FoldGeneratorTests/testFoldGeneratorMultipleFiles.1.swift
+++ b/Tests/MetaTests/Generators/__Snapshots__/FoldGeneratorTests/testFoldGeneratorMultipleFiles.1.swift
@@ -1,0 +1,41 @@
+import Bow
+import BowOptics
+import Foundation
+
+
+// MARK: - Generated from file Company.swift
+
+extension Company {
+    static var employeesFold: Fold<Company, Employee> {
+        employeesLens + ArrayK<Employee>.fold
+    }
+}
+
+extension Employee {
+    static var phonesFold: Fold<Employee, String> {
+        phonesLens + NEA<String>.fold
+    }
+
+    static var emailsFold: Fold<Employee, String> {
+        emailsLens + NonEmptyArray<String>.fold
+    }
+}
+
+
+// MARK: - Generated from file Author.swift
+
+extension Author {
+    static var socialFold: Fold<Author, SocialNetwork> {
+        socialLens + Array<SocialNetwork>.fold
+    }
+}
+
+
+// MARK: - Generated from file Article.swift
+
+extension Blog {
+    static var articlesFold: Fold<Blog, Article> {
+        articlesLens + [Article].fold
+    }
+}
+

--- a/Tests/MetaTests/Visitors/FoldVisitorTests.swift
+++ b/Tests/MetaTests/Visitors/FoldVisitorTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+import Meta
+import SnapshotTesting
+
+class FoldVisitorTests: XCTestCase {
+    func testGeneratedFold() {
+        assertSnapshot(matching: URL.meta.fixtures.file(.article), as: .fold)
+    }
+    
+    func testGeneratedFoldForBowArrayKandNEA() {
+        assertSnapshot(matching: URL.meta.fixtures.file(.company), as: .fold)
+    }
+}

--- a/Tests/MetaTests/Visitors/__Snapshots__/FoldVisitorTests/testGeneratedFold.1.txt
+++ b/Tests/MetaTests/Visitors/__Snapshots__/FoldVisitorTests/testGeneratedFold.1.txt
@@ -1,0 +1,6 @@
+extension Blog {
+    static var articlesFold: Fold<Blog, Article> {
+        articlesLens + [Article].fold
+    }
+}
+

--- a/Tests/MetaTests/Visitors/__Snapshots__/FoldVisitorTests/testGeneratedFoldForBowArrayKandNEA.1.txt
+++ b/Tests/MetaTests/Visitors/__Snapshots__/FoldVisitorTests/testGeneratedFoldForBowArrayKandNEA.1.txt
@@ -1,0 +1,22 @@
+extension Blog {
+    static var articlesFold: Fold<Blog, Article> {
+        articlesLens + [Article].fold
+    }
+}
+
+extension Company {
+    static var employeesFold: Fold<Company, Employee> {
+        employeesLens + ArrayK<Employee>.fold
+    }
+}
+
+extension Employee {
+    static var phonesFold: Fold<Employee, String> {
+        phonesLens + NEA<String>.fold
+    }
+
+    static var emailsFold: Fold<Employee, String> {
+        emailsLens + NonEmptyArray<String>.fold
+    }
+}
+

--- a/bow-meta.xcodeproj/project.pbxproj
+++ b/bow-meta.xcodeproj/project.pbxproj
@@ -61,6 +61,11 @@
 		11F274C4234F6F2F00BC4CFB /* TraversalGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F274C3234F6F2F00BC4CFB /* TraversalGenerator.swift */; };
 		11F274C6234F6F5F00BC4CFB /* TraversalGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F274C5234F6F5F00BC4CFB /* TraversalGeneratorTests.swift */; };
 		11F274C9234F6FAA00BC4CFB /* testTraversalGeneratorMultipleFiles.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F274C8234F6FAA00BC4CFB /* testTraversalGeneratorMultipleFiles.1.swift */; };
+		11F274CB234F7B4F00BC4CFB /* FoldVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F274CA234F7B4F00BC4CFB /* FoldVisitor.swift */; };
+		11F274CE234F7BF000BC4CFB /* FoldVisitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F274CC234F7BE900BC4CFB /* FoldVisitorTests.swift */; };
+		11F274D0234F7C5300BC4CFB /* FoldGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F274CF234F7C5300BC4CFB /* FoldGenerator.swift */; };
+		11F274D3234F7CF100BC4CFB /* FoldGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F274D1234F7CE000BC4CFB /* FoldGeneratorTests.swift */; };
+		11F274D7234F7D7200BC4CFB /* testFoldGeneratorMultipleFiles.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F274D5234F7D4D00BC4CFB /* testFoldGeneratorMultipleFiles.1.swift */; };
 		8BFE7E3E234DE843003E97BF /* URL+Paths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFE7E3D234DE843003E97BF /* URL+Paths.swift */; };
 /* End PBXBuildFile section */
 
@@ -145,6 +150,11 @@
 		11F274C3234F6F2F00BC4CFB /* TraversalGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraversalGenerator.swift; sourceTree = "<group>"; };
 		11F274C5234F6F5F00BC4CFB /* TraversalGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraversalGeneratorTests.swift; sourceTree = "<group>"; };
 		11F274C8234F6FAA00BC4CFB /* testTraversalGeneratorMultipleFiles.1.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = testTraversalGeneratorMultipleFiles.1.swift; sourceTree = "<group>"; };
+		11F274CA234F7B4F00BC4CFB /* FoldVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoldVisitor.swift; sourceTree = "<group>"; };
+		11F274CC234F7BE900BC4CFB /* FoldVisitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoldVisitorTests.swift; sourceTree = "<group>"; };
+		11F274CF234F7C5300BC4CFB /* FoldGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoldGenerator.swift; sourceTree = "<group>"; };
+		11F274D1234F7CE000BC4CFB /* FoldGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoldGeneratorTests.swift; sourceTree = "<group>"; };
+		11F274D5234F7D4D00BC4CFB /* testFoldGeneratorMultipleFiles.1.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = testFoldGeneratorMultipleFiles.1.swift; sourceTree = "<group>"; };
 		8BFE7E3D234DE843003E97BF /* URL+Paths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Paths.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -273,6 +283,7 @@
 				113746E72343A51A00D9C1AD /* ComputedPropertyVisitor.swift */,
 				113746E92343A56D00D9C1AD /* CopyVisitor.swift */,
 				113746E52343A4ED00D9C1AD /* FieldVisitor.swift */,
+				11F274CA234F7B4F00BC4CFB /* FoldVisitor.swift */,
 				113746E32343A47D00D9C1AD /* ImportVisitor.swift */,
 				111F8502234DCDBB003FE646 /* IsoVisitor.swift */,
 				11039BF6234E845B0022EE33 /* LensVisitor.swift */,
@@ -298,6 +309,7 @@
 			children = (
 				11433402234B3EAF00BFF775 /* __Snapshots__ */,
 				114333FD234B3DC700BFF775 /* CopyGeneratorTests.swift */,
+				11F274D1234F7CE000BC4CFB /* FoldGeneratorTests.swift */,
 				111F850B234DD2BE003FE646 /* IsoGeneratorTests.swift */,
 				11039BFD234E881C0022EE33 /* LensGeneratorTests.swift */,
 				116867FE234F4D9500976262 /* OptionalGeneratorTests.swift */,
@@ -318,6 +330,7 @@
 		11433402234B3EAF00BFF775 /* __Snapshots__ */ = {
 			isa = PBXGroup;
 			children = (
+				11F274D4234F7D4D00BC4CFB /* FoldGeneratorTests */,
 				11433403234B3EAF00BFF775 /* CopyGeneratorTests */,
 				111F850E234DD338003FE646 /* IsoGeneratorTests */,
 				11039BFF234E885D0022EE33 /* LensGeneratorTests */,
@@ -367,6 +380,7 @@
 			isa = PBXGroup;
 			children = (
 				11433422234B50E200BFF775 /* CopyGenerator.swift */,
+				11F274CF234F7C5300BC4CFB /* FoldGenerator.swift */,
 				111F8509234DD28D003FE646 /* IsoGenerator.swift */,
 				11039BFB234E87DC0022EE33 /* LensGenerator.swift */,
 				116867FC234F4D2D00976262 /* OptionalGenerator.swift */,
@@ -423,6 +437,7 @@
 			children = (
 				111F84FF234DCA98003FE646 /* CopyVisitorTests.swift */,
 				119DD0A12344E5BC00E1E62D /* FieldVisitorTests.swift */,
+				11F274CC234F7BE900BC4CFB /* FoldVisitorTests.swift */,
 				119DD09E2344E3E600E1E62D /* ImportVisitorTests.swift */,
 				111F8506234DD16E003FE646 /* IsoVisitorTests.swift */,
 				11039BF8234E86590022EE33 /* LensVisitorTests.swift */,
@@ -448,6 +463,14 @@
 				11F274C8234F6FAA00BC4CFB /* testTraversalGeneratorMultipleFiles.1.swift */,
 			);
 			path = TraversalGeneratorTests;
+			sourceTree = "<group>";
+		};
+		11F274D4234F7D4D00BC4CFB /* FoldGeneratorTests */ = {
+			isa = PBXGroup;
+			children = (
+				11F274D5234F7D4D00BC4CFB /* testFoldGeneratorMultipleFiles.1.swift */,
+			);
+			path = FoldGeneratorTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -647,6 +670,7 @@
 			files = (
 				11433412234B439200BFF775 /* FileSystem.swift in Sources */,
 				11433423234B50E200BFF775 /* CopyGenerator.swift in Sources */,
+				11F274D0234F7C5300BC4CFB /* FoldGenerator.swift in Sources */,
 				113746E82343A51A00D9C1AD /* ComputedPropertyVisitor.swift in Sources */,
 				11039BFC234E87DC0022EE33 /* LensGenerator.swift in Sources */,
 				11433417234B468D00BFF775 /* CodeGenerator.swift in Sources */,
@@ -656,6 +680,7 @@
 				1143341F234B4F3700BFF775 /* Kleisli.swift in Sources */,
 				11433421234B4FAA00BFF775 /* IO.swift in Sources */,
 				11F274C4234F6F2F00BC4CFB /* TraversalGenerator.swift in Sources */,
+				11F274CB234F7B4F00BC4CFB /* FoldVisitor.swift in Sources */,
 				114333F2234B2AF900BFF775 /* CodegenVisitor.swift in Sources */,
 				1143340F234B430C00BFF775 /* Set.swift in Sources */,
 				1143341D234B4B4600BFF775 /* SwiftSyntaxGenerator.swift in Sources */,
@@ -675,10 +700,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				111F8518234DD545003FE646 /* testIsoGeneratorMultipleFiles.1.swift in Sources */,
+				11F274CE234F7BF000BC4CFB /* FoldVisitorTests.swift in Sources */,
+				11F274D3234F7CF100BC4CFB /* FoldGeneratorTests.swift in Sources */,
 				8BFE7E3E234DE843003E97BF /* URL+Paths.swift in Sources */,
 				119DD09B2344E35400E1E62D /* Author.swift in Sources */,
 				111F8508234DD1BF003FE646 /* IsoVisitorTests.swift in Sources */,
 				119DD0982344E27400E1E62D /* Article.swift in Sources */,
+				11F274D7234F7D7200BC4CFB /* testFoldGeneratorMultipleFiles.1.swift in Sources */,
 				119DD0A32344E5C100E1E62D /* FieldVisitorTests.swift in Sources */,
 				116867FF234F4D9500976262 /* OptionalGeneratorTests.swift in Sources */,
 				111F8501234DCABB003FE646 /* CopyVisitorTests.swift in Sources */,

--- a/bow-meta.xcodeproj/project.pbxproj
+++ b/bow-meta.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		111F850D234DD2D6003FE646 /* IsoGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111F850B234DD2BE003FE646 /* IsoGeneratorTests.swift */; };
 		111F8518234DD545003FE646 /* testIsoGeneratorMultipleFiles.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111F8512234DD4D3003FE646 /* testIsoGeneratorMultipleFiles.1.swift */; };
 		111F8519234DD545003FE646 /* testCopyGeneratorMultipleFiles.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111F8514234DD4DA003FE646 /* testCopyGeneratorMultipleFiles.1.swift */; };
+		11311A6823509CA000039794 /* String+NoArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11311A6723509CA000039794 /* String+NoArray.swift */; };
 		113746C323439F9C00D9C1AD /* Meta.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 113746B923439F9C00D9C1AD /* Meta.framework */; };
 		113746DC2343A3F500D9C1AD /* SwiftSyntax in Frameworks */ = {isa = PBXBuildFile; productRef = 113746DB2343A3F500D9C1AD /* SwiftSyntax */; };
 		113746DF2343A43700D9C1AD /* BowEffects in Frameworks */ = {isa = PBXBuildFile; productRef = 113746DE2343A43700D9C1AD /* BowEffects */; };
@@ -107,6 +108,7 @@
 		111F850B234DD2BE003FE646 /* IsoGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IsoGeneratorTests.swift; sourceTree = "<group>"; };
 		111F8512234DD4D3003FE646 /* testIsoGeneratorMultipleFiles.1.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = testIsoGeneratorMultipleFiles.1.swift; sourceTree = "<group>"; };
 		111F8514234DD4DA003FE646 /* testCopyGeneratorMultipleFiles.1.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = testCopyGeneratorMultipleFiles.1.swift; sourceTree = "<group>"; };
+		11311A6723509CA000039794 /* String+NoArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+NoArray.swift"; sourceTree = "<group>"; };
 		113746B923439F9C00D9C1AD /* Meta.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Meta.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		113746BD23439F9C00D9C1AD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		113746C223439F9C00D9C1AD /* MetaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MetaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -216,6 +218,7 @@
 		113746AF23439F9C00D9C1AD = {
 			isa = PBXGroup;
 			children = (
+				11311A6723509CA000039794 /* String+NoArray.swift */,
 				113746D323439FE000D9C1AD /* Sources */,
 				113746D423439FEC00D9C1AD /* Tests */,
 				113746BA23439F9C00D9C1AD /* Products */,
@@ -686,6 +689,7 @@
 				1143341D234B4B4600BFF775 /* SwiftSyntaxGenerator.swift in Sources */,
 				113746E42343A47D00D9C1AD /* ImportVisitor.swift in Sources */,
 				111F8503234DCDBB003FE646 /* IsoVisitor.swift in Sources */,
+				11311A6823509CA000039794 /* String+NoArray.swift in Sources */,
 				116867FD234F4D2D00976262 /* OptionalGenerator.swift in Sources */,
 				114333F8234B355800BFF775 /* GenerateCode.swift in Sources */,
 				113746EA2343A56D00D9C1AD /* CopyVisitor.swift in Sources */,


### PR DESCRIPTION
## Issues

- Closes #9

## Goal

Generate Folds for every array field in a struct.

## Implementation details

A new visitor is created to visit `struct` declarations, extract their array fields and create an extension to add a static computed property containing the Fold for each one of them.

A new generator is created using this visitor and passing a default set of imports (`BowOptics` need to be imported in the generated code).

## Testing details

Generated code is tested using Snapshot testing and the generated output is put back into the project to guarantee its compilation.